### PR TITLE
fix utls conn CloseWrite

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -1471,12 +1471,9 @@ func (c *Conn) closeNotify() error {
 	defer c.out.Unlock()
 
 	if !c.closeNotifySent {
-		// Set a Write Deadline to prevent possibly blocking forever.
-		c.SetWriteDeadline(time.Now().Add(time.Second * 5))
 		c.closeNotifyErr = c.sendAlertLocked(alertCloseNotify)
 		c.closeNotifySent = true
 		// Any subsequent writes will fail.
-		c.SetWriteDeadline(time.Now())
 		c.CloseRawConnWrite()
 	}
 	return c.closeNotifyErr

--- a/conn.go
+++ b/conn.go
@@ -1472,6 +1472,8 @@ func (c *Conn) closeNotify() error {
 	defer c.out.Unlock()
 
 	if !c.closeNotifySent {
+		// Set a Write Deadline to prevent possibly blocking forever.
+		c.SetWriteDeadline(time.Now().Add(time.Second * 5))
 		c.closeNotifyErr = c.sendAlertLocked(alertCloseNotify)
 		c.closeNotifySent = true
 		// Any subsequent writes will fail.

--- a/conn.go
+++ b/conn.go
@@ -171,8 +171,9 @@ func (c *Conn) NetConn() net.Conn {
 func (c *Conn) CloseRawConnWrite() error {
 	if tcpConn, ok := c.conn.(WriteCloser); ok {
 		return tcpConn.CloseWrite()
+	} else {
+		return c.SetWriteDeadline(time.Now())
 	}
-	return nil
 }
 
 // A halfConn represents one direction of the record layer


### PR DESCRIPTION
utls conn 未正常关闭原始tcp.conn。在代理客户端和服务端都为sing-box vless+reality协议时，处理请求goroutine未正常退出，导致内存泄漏